### PR TITLE
update 404 error url docs.drip.art to comfydocs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ npx mintlify dev
 
 ### Create a PR
 
-Create a PR. Once it is accepted Vercel will deploy the change to https://docs.drip.art.
+Create a PR. Once it is accepted Vercel will deploy the change to https://comfydocs.org.

--- a/mint.json
+++ b/mint.json
@@ -35,7 +35,7 @@
     {
       "name": "Documentation",
       "icon": "book-open-cover",
-      "url": "https://docs.drip.art"
+      "url": "https://comfydocs.org"
     },
     {
       "name": "Matrix Community",


### PR DESCRIPTION
- noticed a 404 error when user clicks 'documentation' on hamburger sidebar because it was redirecting to our old url 