### PR TITLE
Add Registry Tutorial Video 

### DIFF
--- a/registry/overview.mdx
+++ b/registry/overview.mdx
@@ -18,6 +18,10 @@ The Comfy Registry helps the community by standardizing the development of custo
 
 ## Publishing to the Registry
 
+### Watch a Tutorial
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/JmjzP1jwbfY?si=b3gPqnqyoe9OmtZZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ### Create a Publisher
 
 A publisher is an identity that can publish custom nodes to the registry. Every custom node needs to include a publisher identifier in the pyproject.toml [file]().

--- a/registry/overview.mdx
+++ b/registry/overview.mdx
@@ -20,7 +20,7 @@ The Comfy Registry helps the community by standardizing the development of custo
 
 ### Watch a Tutorial
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/JmjzP1jwbfY?si=b3gPqnqyoe9OmtZZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe height="415" src="https://www.youtube.com/embed/JmjzP1jwbfY?si=b3gPqnqyoe9OmtZZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style={{ width: "100%", borderRadius: "0.5rem" }}></iframe>
 
 ### Create a Publisher
 

--- a/registry/overview.mdx
+++ b/registry/overview.mdx
@@ -20,7 +20,7 @@ The Comfy Registry helps the community by standardizing the development of custo
 
 ### Watch a Tutorial
 
-<iframe height="415" src="https://www.youtube.com/embed/JmjzP1jwbfY?si=b3gPqnqyoe9OmtZZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style={{ width: "100%", borderRadius: "0.5rem" }}></iframe>
+<iframe height="415" src="https://www.youtube.com/embed/WhOZZOgBggU?si=6TyvhJJadmQ65uXC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style={{ width: "100%", borderRadius: "0.5rem" }}></iframe>
 
 ### Create a Publisher
 


### PR DESCRIPTION
Added the video directly under 

### Publishing to the Registry Section

but can move it down to the bottom of the page too!

![image](https://github.com/drip-art/docs/assets/162922985/69671190-7fd0-4a2a-b1b1-ec4a7006c070)

The tutorial video: https://youtu.be/WhOZZOgBggU?si=wXSQKvvavuf1On8z